### PR TITLE
Bumped waterline dependency in package.json to 0.12.2.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "bluebird": "^3.0.6",
     "traverse": "^0.6.6",
     "underscore": "^1.8.3",
-    "waterline": "^0.10.28",
+    "waterline": "^0.12.2",
     "waterline-sqlite3": "^1.0.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "traverse": "^0.6.6",
     "underscore": "^1.8.3",
     "waterline": "^0.12.2",
-    "waterline-sqlite3": "^1.0.0"
+    "waterline-sqlite3": "^1.0.3"
   },
   "peerDependencies": {
     "nxus-core": "^3.0.0-0"
@@ -51,7 +51,7 @@
     "sinon": "^1.17.2",
     "babel-preset-es2015": "^6.9.0",
     "babel-cli": "^6.9.0",
-    "sails-memory": "^0.10.5",
+    "sails-memory": "^0.10.7",
     "babel-core": "^6.9.0"
   }
 }

--- a/test/Storage.js
+++ b/test/Storage.js
@@ -205,7 +205,9 @@ describe("Storage", () => {
         app.get('storage').emit.calledWith('model.create.one').should.be.true
         obj.color = 'blue'
         return obj.save()
+          .then(() => obj) // save doesn't return object as of waterline 0.11.0
       }).then((obj) => {
+console.log("****** obj", obj)
         app.get('storage').emit.calledWith('model.update').should.be.true
         app.get('storage').emit.calledWith('model.update.one').should.be.true
         return obj.destroy()
@@ -257,6 +259,7 @@ describe("Storage", () => {
         app.get('storage').emit.calledWith('model.create.geo').should.be.true
         obj.geo = {}
         return obj.save()
+          .then(() => obj) // save doesn't return object as of waterline 0.11.0
       }).then((obj) => {
         app.get('storage').emit.calledWith('model.update').should.be.true
         app.get('storage').emit.calledWith('model.update.geo').should.be.true


### PR DESCRIPTION
Provides .populate() method that can populate multiple relations.

We talked about this already. I'll plan to go ahead and merge this shortly unless I hear otherwise.