### PR TITLE
HasModels: Constructor options

### DIFF
--- a/src/HasModels.js
+++ b/src/HasModels.js
@@ -27,12 +27,12 @@ export default class HasModels extends NxusModule {
       if (_.isArray(mods)) {
         mods = _.object(mods, mods)
       }
-      for (let id in mods) {
-        storage.getModel(id).then((model) => {
+      return Promise.all(Object.keys(mods).map((id) => {
+        return storage.getModel(id).then((model) => {
           this.models[id] = model;
           this.models[mods[id]] = model;
         })
-      }
+      }))
     })
   }
 

--- a/src/HasModels.js
+++ b/src/HasModels.js
@@ -13,7 +13,7 @@ import {storage} from './index'
  * 
  */
 export default class HasModels extends NxusModule {
-  constructor({modelNames = null}={}) {
+  constructor({modelNames=null}={}) {
     super()
     this._modelNames = modelNames
     this.models = {}
@@ -38,13 +38,13 @@ export default class HasModels extends NxusModule {
   }
 
   /**
-   * Override to define the model names to access
+   * Deprecated: Override to define the model names to access
    * @return {array|object} Model identities to add to this.models, or object of {identity: name}
    * @example modelNames() { 
    *   return ['user']
    * }
    */
   modelNames () {
-    return this.modelNames || this._model_identities
+    return this._modelNames || this._model_identities
   }
 }

--- a/src/HasModels.js
+++ b/src/HasModels.js
@@ -13,8 +13,9 @@ import {storage} from './index'
  * 
  */
 export default class HasModels extends NxusModule {
-  constructor() {
+  constructor({modelNames = null}={}) {
     super()
+    this._modelNames = modelNames
     this.models = {}
     this._model_identities = []
 
@@ -44,6 +45,6 @@ export default class HasModels extends NxusModule {
    * }
    */
   modelNames () {
-    return this._model_identities
+    return this.modelNames || this._model_identities
   }
 }


### PR DESCRIPTION
Leaves the old modelNames() method for deprecated compatibility.