### PR TITLE
Work around for npm-dependency bug with waterline-sqlite3 1.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "traverse": "^0.6.6",
     "underscore": "^1.8.3",
     "waterline": "^0.12.2",
-    "waterline-sqlite3": "^1.0.3"
+    "waterline-sqlite3": "1.0.3"
   },
   "devDependencies": {
     "documentation": "^4.0.0-beta9",


### PR DESCRIPTION
Latest version of waterline-sqlite won't build due to postinstall dependency on gulp (+ more?)