### PR TITLE
Waterline sessions for router.sessionMiddleware

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,6 @@
 {
   "plugins": [
+    "transform-async-to-generator",
     "transform-function-bind",
     "transform-object-rest-spread",
     "transform-es2015-modules-commonjs"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "connect-waterline": "^0.1.0",
     "express-session": "^1.15.5",
     "geojson-rewind": "^0.2.0",
-    "nxus-core": "^4.0.0-0",
+    "nxus-core": "^4.0.1",
+    "nxus-router": "^4.0.0",
     "underscore": "^1.8.3",
     "waterline": "^0.12.2",
     "waterline-sqlite3": "1.0.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nxus-storage",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Storage framework for Nxus applications",
   "main": "lib/",
   "scripts": {
@@ -34,6 +34,8 @@
     "@turf/centroid": "^4.2.0",
     "@turf/meta": "^4.2.0",
     "bluebird": "^3.0.6",
+    "connect-waterline": "^0.1.0",
+    "express-session": "^1.15.5",
     "geojson-rewind": "^0.2.0",
     "nxus-core": "^4.0.0-0",
     "underscore": "^1.8.3",

--- a/src/index.js
+++ b/src/index.js
@@ -34,18 +34,16 @@ class Storage extends NxusModule {
     this.connections = null;
     this._adapters = {}
 
-    application.once('init', () => {
-      return Promise.all([
-        this._setupAdapter(),
-      ]);
+    this._configured = application.once('init', () => {
+      return this._setupAdapter()
     });
 
     application.onceAfter('load', () => {
-      return this._connectDb();
+      return this._connectDb()
     });
 
     application.once('stop', () => {
-      return this._disconnectDb();
+      return this._disconnectDb()
     })
   }
 
@@ -120,6 +118,18 @@ class Storage extends NxusModule {
     });
   }
 
+  /**
+   * After init, get the waterline config with populated adapter modules
+   * @return {Promise}  Config object for waterline
+   */
+  async getWaterlineConfig() {
+    await this._configured
+    return {
+      adapters: this._adapters,
+      connections: this.config.connections
+    }
+  }
+  
   // Internal
   
   _setupAdapter () {

--- a/src/modules/waterline-sessions/index.js
+++ b/src/modules/waterline-sessions/index.js
@@ -1,0 +1,33 @@
+import {application} from 'nxus-core'
+import RouterSessions from 'nxus-router/lib/modules/router-sessions'
+var session = require('express-session');
+var WaterlineStore = require('connect-waterline')(session);
+
+class WaterlineSessions extends RouterSessions {
+
+  _defaultConfig() {
+    let config = super._defaultConfig()
+    config.connectionName = 'default'
+    config.resave = false
+    config.saveUninitialized = false
+    return config
+  }
+  
+  _sessionName() {
+    return 'waterline-session'
+  }
+  
+  async _createStore(settings) {
+    let config = await application.get('storage').getWaterlineConfig()
+    let options = {
+      adapters: config.adapters,
+      connections: {
+        'connect-waterline': config.connections[this.config.connectionName]
+      }
+    }
+    return new WaterlineStore(options)
+  }
+}
+
+export default WaterlineSessions
+export let waterlineSessions = WaterlineSessions.getProxy()

--- a/src/modules/waterline-sessions/index.js
+++ b/src/modules/waterline-sessions/index.js
@@ -3,6 +3,21 @@ import RouterSessions from 'nxus-router/lib/modules/router-sessions'
 var session = require('express-session');
 var WaterlineStore = require('connect-waterline')(session);
 
+/**
+ * WaterlineSessions provides a `nxus-router` session middleware using `connect-waterline`
+ * 
+ * The session model will be saved in your configured 'default' database connection.
+ * 
+ * ## Usage:
+ * 
+ *  Application config (.nxusrc) for router:
+ * 
+ *    "router": {
+ *      "sessionStoreName": "waterline-session"
+ *    }
+ * 
+ */
+
 class WaterlineSessions extends RouterSessions {
 
   _defaultConfig() {


### PR DESCRIPTION
Provide a new session middleware that can be enabled for an application with the config `{router: {sessionStoreName: 'waterline-sessions'}}`.