### PR TITLE
Fix to handling of turf modules import.

### DIFF
--- a/src/GeoModel.js
+++ b/src/GeoModel.js
@@ -3,10 +3,9 @@ import Promise from 'bluebird'
 
 import _ from "underscore"
 import rewind from 'geojson-rewind'
-import turf from '@turf/meta'
-import turfCentroid from '@turf/centroid'
-
-var turfCentroidFunc = turfCentroid
+import * as turfMeta from '@turf/meta'
+import {default as turfCentroid} from '@turf/centroid'
+const turf = Object.assign({centroid: turfCentroid}, turfMeta)
 
 /** Cleans up polygon coordinates.
  * For each linear ring that defines the polygon, it removes repeated
@@ -300,7 +299,7 @@ const GeoModel = BaseModel.extend(
       let val = record[this.geometryFeatureField], geo
       if (val) {
         try {
-          let feature = turfCentroidFunc(val)
+          let feature = turf.centroid(val)
           geo = feature.geometry
         }
         catch (e) {}


### PR DESCRIPTION
In `GeoModel.js`, we selectively import turf submodules and assemble them into a `turf` object (doing by hand more or less what Turf's "builder" utility does). Recent changes to Babel broke this code. The new code works again, and it aligns closely to what Turf itself does to assemble the full Turf configuration in `turf/index.js`, so hopefully it's more resistant to breakage.