### PR TITLE
Delay model registration to avoid duplicate models from repeated call…

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,6 +3,7 @@
     "transform-async-to-generator",
     "transform-function-bind",
     "transform-object-rest-spread",
+    "transform-runtime",
     "transform-es2015-modules-commonjs"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "babel-core": "^6.9.0",
     "babel-plugin-transform-class-properties": "^6.11.5",
     "babel-plugin-transform-function-bind": "^6.8.0",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-es2015": "^6.9.0",
     "chai": "^3.4.1",
     "documentation": "^4.0.0-beta9",

--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,7 @@ class Storage extends NxusModule {
     this.collections = {};
     this.connections = null;
     this._adapters = {}
+    this._collections = {}
 
     this._configured = application.once('init', () => {
       return this._setupAdapter()
@@ -70,7 +71,7 @@ class Storage extends NxusModule {
   
   model (model) {
     this.log.debug('Registering model', model.prototype.identity)
-    this.waterline.loadCollection(model)
+    this._collections[model.prototype.identity] = model
   }
 
   /**
@@ -175,7 +176,8 @@ class Storage extends NxusModule {
     return this.waterline.initializeAsync({
       adapters: this._adapters,
       connections: this.config.connections,
-      defaults: this.config.defaults
+      defaults: this.config.defaults,
+      collections: Object.values(this._collections)
     }).then((obj) => {
       this.connections = obj.connections;
       this.collections = obj.collections;

--- a/src/test/index.js
+++ b/src/test/index.js
@@ -106,6 +106,55 @@ describe("Storage", () => {
     
 
   });
+  describe("Model Dupes", () => {
+    beforeEach(() => {
+      storage.config = {
+        adapters: {
+          "default": "sails-memory"
+        },
+        connections: {
+          'default': {
+            adapter: 'default'
+          }
+        }
+      }
+      
+      var Dummy = BaseModel.extend({
+        identity: 'dummy',
+        connection: 'default',
+        attributes: {
+          name: 'string'
+        }
+      });
+
+      // Shortcut around gather stub
+      storage.model(Dummy)
+      // Register twice is ok
+      storage.model(Dummy)
+      storage._setupAdapter()
+      return storage._connectDb()
+    });
+
+    afterEach(() => {
+      return storage._disconnectDb()
+    })
+
+    it("should have a collection of models", () => {
+      storage.collections.should.not.be.null;
+      storage.connections.should.not.be.null;
+      storage.collections.should.have.property('dummy');
+    });
+    it("should return model by identity", () => {
+      var dummy = storage.getModel('dummy')
+      dummy.should.exist
+      dummy.identity.should.equal('dummy')
+      return dummy.create({name:"test"}).then((obj) => {
+        obj.name.should.equal("test")
+      })
+    });
+    
+
+  });
   describe("Model Dir", () => {
     beforeEach(() => {
       storage.config = {


### PR DESCRIPTION
or multiple HasModels in root.