### PR TITLE
Removed default adapters and connections definitions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "postversion": "npm run build-docs && git push && git push --tags",
     "test": "NODE_ENV=test mocha --recursive --compilers js:babel-register -R spec src/**/*",
     "compile": "rm -rf lib/; babel src --out-dir lib",
-    "prepublish": "npm run compile",
-    "postpublish": "npm run build-docs && npm run publish-docs",
+    "prepare": "npm run compile",
     "build-docs": "NAME=\"$(npm view . name)\" VERSION=\"$(npm view . version)\" && documentation readme --readme-file ./README.md --section=$NAME --name $NAME --project-version $VERSION --config documentation.yml ./src/index.js ./src/PointModel.js ./src/modules/waterline-sessions/index.js",
     "publish-docs": "npm run build-docs && if [ -z `git diff --name-only ./README.md` ]; then exit 0; fi && git add ./README.md && git commit -m 'Updated README API Docs' && git push",
     "build-shared-docs": "NAME=\"${NAME:-$npm_package_name}\" VERSION=\"${VERSION:-$npm_package_version}\" OUTPUT=\"${OUTPUT:-./docs}\" && echo documentation build --output $OUTPUT --github --format html --name $NAME --project-version $VERSION --config documentation.yml ./src/index.js ./src/PointModel.js ./src/modules/waterline-sessions/index.js"
@@ -40,8 +39,7 @@
     "nxus-core": "^4.0.1",
     "nxus-router": "^4.0.0",
     "underscore": "^1.8.3",
-    "waterline": "^0.12.2",
-    "waterline-sqlite3": "1.0.3"
+    "waterline": "^0.12.2"
   },
   "devDependencies": {
     "babel-cli": "^6.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nxus-storage",
-  "version": "4.0.7",
+  "version": "4.0.8",
   "description": "Storage framework for Nxus applications",
   "main": "lib/",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -52,12 +52,8 @@ class Storage extends NxusModule {
   _userConfig () {
     return {
       adapters: {
-        'default': "waterline-sqlite3"
       },
       connections: {
-        'default': {
-          adapter: 'default', // or 'memory'
-        }
       }
     };
   }

--- a/src/test/index.js
+++ b/src/test/index.js
@@ -50,8 +50,9 @@ describe("Storage", () => {
       return app.emit('init').then(() => {
         return app.emit('load')
       }).then(() => {
-        storage._adapters.should.have.property('default');
+        storage.should.have.property('_adapters');
         storage.should.have.property('config');
+        storage.config.should.have.property('adapters');
         storage.config.should.have.property('connections');
         storage.should.have.property('connections');
         storage.connections.should.not.be.null


### PR DESCRIPTION
Motivated by need to get rid of waterline-sqlite3 dependency, which is not well supported on node v10 or v12.

Instead of trying to switch the defaults to something else (e.g. sails-mongo), decided it was simpler to remove the defaults. This seems pretty safe for `adapters`, since the `waterline-sqlite3` default wasn't useful, and seems to have been universally redefined. The `connections` default also seems to be universally redefined, because of the need to define the `url` attribute.