### PR TITLE
Fix to emit destroy event for each model instance destroyed.

### DIFF
--- a/src/BaseModel.js
+++ b/src/BaseModel.js
@@ -77,8 +77,8 @@ var BaseModel = Waterline.Collection.extend(
 
     afterDestroy: function(record, next) {
       if(this.storageModule) {
-        if(record && record[0]) record = record[0]
-        this.storageModule.emitModelEvent('destroy', this.identity, record)
+        for (let rec of record)
+          this.storageModule.emitModelEvent('destroy', this.identity, rec)
       }
       next()
     },


### PR DESCRIPTION
In the current code, when the `destroy()` method is invoked to destroy multiple model instances, destroy events are emitted for only the first of the instances. In the updated code, events are emitted for each of the instances.

(These missing events are a major problem for nxus-searcher, causing it to leave dangling ElasticSearch records.)

(Is it reasonable to emit multiple events like this?)